### PR TITLE
add support for Gnome 44

### DIFF
--- a/resources/metadata.json
+++ b/resources/metadata.json
@@ -5,5 +5,5 @@
   "version": 999,
   "settings-schema": "org.gnome.shell.extensions.extensions-sync",
   "url": "https://github.com/oae/gnome-shell-extensions-sync",
-  "shell-version": ["42", "43"]
+  "shell-version": ["42", "43", "44"]
 }


### PR DESCRIPTION
Updated metadata.json file to support Gnome 44. 
I've made the change manually on my system, and it works fine