### PR TITLE
feat: add gnome 44 support

### DIFF
--- a/resources/metadata.json
+++ b/resources/metadata.json
@@ -5,5 +5,5 @@
   "version": 999,
   "settings-schema": "org.gnome.shell.extensions.extensions-sync",
   "url": "https://github.com/oae/gnome-shell-extensions-sync",
-  "shell-version": ["42", "43"]
+  "shell-version": ["42", "43", "44"]
 }


### PR DESCRIPTION
Working fine on Gnome 44:

![image](https://github.com/oae/gnome-shell-extensions-sync/assets/17055027/2fc941e6-9f35-44e1-aa16-fceba64d1774)
