### PR TITLE
feat: add gnome 44 support

### DIFF
--- a/resources/metadata.json
+++ b/resources/metadata.json
@@ -5,5 +5,5 @@
   "version": 999,
   "settings-schema": "org.gnome.shell.extensions.extensions-sync",
   "url": "https://github.com/oae/gnome-shell-extensions-sync",
-  "shell-version": ["42", "43"]
+  "shell-version": ["42", "43", "44"]
 }


### PR DESCRIPTION
I added support for GNOME 44 by simply adding it to metadata.json line `"shell-version": ["42", "43", "44"]`. I tested the performance on GNOME 44.1 Fedora 38. It works great!

If I didn't take something into account, I will be happy to fix it.